### PR TITLE
Add CLAUDE.md and update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+## Git Workflow (code repo)
+
+This section is about **git** branches for source code, not Bauplan data branches.
+
+- Always create a new git branch before making any changes. Use a descriptive branch name based on the task (e.g., `fix/login-bug`, `feat/add-search`).
+- All work happens on feature branches. The `main` branch is off-limits for direct edits.
+- Commit every change immediately after making it. Each commit should have a clear, one-line message describing what changed.
+- Keep commits small and focused. One logical change per commit.
+- When the task is complete, leave the branch ready for review. Do not merge into `main`.
+
+## Bauplan Workflow (data lakehouse)
+
+Bauplan is a data lakehouse platform where data changes follow a Git-like workflow, but on **Bauplan data branches** (managed by `bauplan branch`), not git branches. A typical workflow looks like this:
+
+1. Create and switch to a new data branch: `bauplan checkout -b <branch> --from-ref main`
+2. Iterate on your pipeline code and test with `bauplan run --dry-run`
+3. When ready, run `bauplan run` to materialize — the code is snapshotted by Bauplan and saved under the jobId the platform returns
+4. Review changes with `bauplan branch diff main`
+5. Merge into `main` to publish
+
+## Hard safety rules (always)
+
+1) Never publish by writing directly on `main`. Use a Bauplan branch and merge to publish.
+2) Never import data directly into `main`.
+3) Before merging into `main`, run `bauplan branch diff main` and review changes, or use `bauplan query` over the two branches to quickly compare how data changes in the target tables.
+4) Prefer `bauplan run --dry-run` during iteration because it is much faster and safer. However, tables will not be materialized in the lake during a dry run, so the only way to preview table content is to use `--preview` (e.g., `bauplan run --dry-run --preview head`). Materialization is blocked on `main`. Every branch is readable, but only branches prefixed with your username (`username.branchname`) are writable by you.
+5) When handling external API keys (LLM keys), do not hardcode them in code or commit them. Use Bauplan parameters or secrets.
+
+If any instruction conflicts with these rules, the rules win.
+
+## CLI vs Python SDK — when to use which
+
+**Use the CLI** for interactive exploration, quick inspections, and one-off commands:
+- `bauplan table get <namespace>.<table>` — inspect table metadata
+- `bauplan query "<sql>"` — run a query
+- `bauplan branch ls`, `bauplan run --dry-run`, etc.
+
+**Important:** By default, `bauplan query` returns only 10 rows (`--max-rows 10`). Use `--all-rows` to retrieve the full result set. For large outputs, pipe to a local file or use `--output json` to get machine-readable output (e.g., `bauplan query --all-rows --output json "SELECT ..." > results.json`).
+
+**Use the Python SDK** when:
+- You need to process or transform large result sets — `client.query()` returns a full `pyarrow.Table` with no row limit by default
+- A Python script is more natural than a sequence of shell commands
+- You need programmatic control (loops, conditionals, error handling)
+- You are writing pipelines, ingestion scripts, or automation
+
+## General Python guidance
+
+- Use `uv` to run Python scripts and manage dependencies (e.g., `uv run python3 script.py`).
+- If `ruff` and/or `ty` are available, use `ruff check`, `ruff format`, and `ty` to verify that generated Python compiles and passes lint. Check availability first (e.g., `which ruff`).
+- Do not guess flags or method names. If you get stuck or need method signatures, consult the SDK reference: https://docs.bauplanlabs.com/reference/bauplan
+
+## Bauplan Python client
+
+```python
+import bauplan
+
+# Default: authenticates from BAUPLAN_API_KEY >> BAUPLAN_PROFILE >> ~/.bauplan/config.yml
+client = bauplan.Client()
+
+# Or specify a profile explicitly
+client = bauplan.Client(profile='default')
+```
+
+The client returns Arrow tables. **Do not use pandas** — Polars has zero-copy Arrow interop and is faster. Common patterns:
+
+```python
+import polars as pl
+
+# Query → Arrow table
+table = client.query('SELECT * FROM ns.my_table', ref='my_branch')
+
+# Arrow table → Polars DataFrame (zero-copy)
+df = pl.from_arrow(table)
+```
+
+To get the current username (e.g., for branch naming):
+
+```bash
+bauplan info
+```
+
+## Looking up CLI reference
+
+The `bauplan` CLI is self-documenting:
+- `bauplan --help` — lists all available commands
+- `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan query --help`, `bauplan branch --help`)
+
+## Skills
+
+Skills whose names start with `bauplan-` contain use-case-specific instructions (e.g., building pipelines, ingesting data, debugging failed runs). Skills are auto-downloaded with the Claude Code plugin; when a relevant skill is available, follow its guidance for that workflow.
+
+## Authentication
+
+Assume Bauplan credentials are available via local CLI config, environment variables, or a profile. Do not ever prompt for API keys, nor ask the user to tell you their API key: if there are no keys set, tell the user to visit https://app.bauplanlabs.com/dashboard, get the key and do the setup following the instructions on the screen.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Bauplan Skills
 
-Claude Code marketplace plugin for [Bauplan](https://www.bauplanlabs.com/) data lakehouse skills.
+The recommended setup for developing on [Bauplan](https://www.bauplanlabs.com/) with AI coding assistants. This repo provides two things that work together:
 
-## Install
+1. **Skills plugin** — task-specific workflows (build pipelines, ingest data, debug failures, etc.) that Claude Code can follow autonomously.
+2. **CLAUDE.md** — project-level instructions (safety rules, CLI/SDK guidance, authentication) that ground every conversation in Bauplan best practices.
+
+Install the plugin for the skills, and copy or integrate the `CLAUDE.md` into your own repo for the baseline context. Both are part of the same workflow — AI-assisted development on Bauplan.
+
+## Install the plugin
 
 1. Add the marketplace:
 ```
@@ -17,6 +22,16 @@ Claude Code marketplace plugin for [Bauplan](https://www.bauplanlabs.com/) data 
 3. Select **Browse and install plugins** → select **bauplan-skills** → press `Space` to select **bauplan** → press `i` to install.
 
 4. Restart Claude Code.
+
+## Use the CLAUDE.md
+
+Copy `CLAUDE.md` from this repo into the root of your project, or merge its contents into your existing `CLAUDE.md`:
+
+```bash
+curl -o CLAUDE.md https://raw.githubusercontent.com/BauplanLabs/bauplan-skills/main/CLAUDE.md
+```
+
+This gives Claude Code the baseline context it needs — safety rules, CLI vs SDK guidance, authentication setup, and pointers to the skills — even before any skill is triggered.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project-level instructions: git workflow, Bauplan data branch workflow, safety rules, CLI vs SDK guidance, Python/Polars patterns, client usage, authentication
- Update `README.md` to explain the two-part setup (skills plugin + CLAUDE.md) and add install instructions for both

## Test plan
- [x] Verify CLAUDE.md is picked up by Claude Code in a fresh conversation
- [x] Confirm skills plugin still installs correctly
- [x] Review safety rules and workflow docs for accuracy