### PR TITLE
[FIX] Fix links pointing to docs which moved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,18 +91,18 @@ Bauplan publishes an LLM-friendly documentation index at `https://docs.bauplanla
 |-------|-----|
 | Python SDK reference | `https://docs.bauplanlabs.com/reference/bauplan.md` |
 | CLI reference | `https://docs.bauplanlabs.com/reference/cli.md` |
-| Standard expectations | `https://docs.bauplanlabs.com/reference/bauplan_standard_expectations.md` |
+| Standard expectations | `https://docs.bauplanlabs.com/reference/bauplan-standard-expectations.md` |
 | Models | `https://docs.bauplanlabs.com/concepts/models.md` |
 | Pipelines | `https://docs.bauplanlabs.com/concepts/pipelines.md` |
 | Tables | `https://docs.bauplanlabs.com/concepts/tables.md` |
 | Namespaces | `https://docs.bauplanlabs.com/concepts/namespaces.md` |
 | Expectations | `https://docs.bauplanlabs.com/concepts/expectations.md` |
-| Data branches | `https://docs.bauplanlabs.com/concepts/git_for_data/data_branches.md` |
-| Import data | `https://docs.bauplanlabs.com/guides/import_data.md` |
-| Schema conflicts | `https://docs.bauplanlabs.com/guides/schema_conflicts.md` |
-| Secrets | `https://docs.bauplanlabs.com/guides/secrets.md` |
-| Parameters | `https://docs.bauplanlabs.com/guides/parameters.md` |
-| Execution model | `https://docs.bauplanlabs.com/overview/execution_model.md` |
+| Data branches | `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md` |
+| Import data | `https://docs.bauplanlabs.com/tutorial/03-import.md` |
+| Schema conflicts | `https://docs.bauplanlabs.com/concepts/schema-conflicts.md` |
+| Secrets | `https://docs.bauplanlabs.com/concepts/pipelines.md` |
+| Parameters | `https://docs.bauplanlabs.com/concepts/pipelines.md` |
+| Execution model | `https://docs.bauplanlabs.com/overview/execution-model.md` |
 
 When unsure about a method, flag, or concept, fetch the relevant page rather than guessing. For the full index: `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
@@ -808,7 +808,7 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - Tables: `https://docs.bauplanlabs.com/concepts/tables.md`
 - Namespaces: `https://docs.bauplanlabs.com/concepts/namespaces.md`
 - Expectations: `https://docs.bauplanlabs.com/concepts/expectations.md`
-- Data branches: `https://docs.bauplanlabs.com/concepts/git_for_data/data_branches.md`
+- Data branches: `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
@@ -236,15 +236,15 @@ See [examples.md](examples.md) for:
 When unsure about a method signature, CLI flag, or concept, fetch the relevant doc page via `WebFetch` rather than guessing. Pages are markdown and LLM-friendly.
 
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
-**Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan_standard_expectations.md`
+**Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan-standard-expectations.md`
 
 **Relevant concept pages:**
 - Models: `https://docs.bauplanlabs.com/concepts/models.md`
 - Pipelines: `https://docs.bauplanlabs.com/concepts/pipelines.md`
 - Projects: `https://docs.bauplanlabs.com/concepts/projects.md`
 - Expectations: `https://docs.bauplanlabs.com/concepts/expectations.md`
-- Execution model: `https://docs.bauplanlabs.com/overview/execution_model.md`
-- Parameters: `https://docs.bauplanlabs.com/guides/parameters.md`
+- Execution model: `https://docs.bauplanlabs.com/overview/execution-model.md`
+- Parameters: `https://docs.bauplanlabs.com/concepts/pipelines#parameters`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
@@ -449,11 +449,10 @@ result = client.query(
 When unsure about a method signature, CLI flag, or concept, fetch the relevant doc page via `WebFetch` rather than guessing. Pages are markdown and LLM-friendly.
 
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
-**Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan_standard_expectations.md`
+**Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan-standard-expectations.md`
 
 **Relevant concept pages:**
 - Expectations: `https://docs.bauplanlabs.com/concepts/expectations.md`
-- Data quality examples: `https://docs.bauplanlabs.com/examples/expectations.md`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
@@ -383,10 +383,10 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
 
 **Relevant concept pages:**
-- Execution model: `https://docs.bauplanlabs.com/overview/execution_model.md`
-- Transactional pipelines: `https://docs.bauplanlabs.com/concepts/git_for_data/transactional_pipelines.md`
-- Commits and refs: `https://docs.bauplanlabs.com/concepts/git_for_data/commits_refs.md`
-- Data branches: `https://docs.bauplanlabs.com/concepts/git_for_data/data_branches.md`
+- Execution model: `https://docs.bauplanlabs.com/overview/execution-model.md`
+- Transactional pipelines: `https://docs.bauplanlabs.com/concepts/git-for-data/transactional-pipelines.md`
+- Commits and refs: `https://docs.bauplanlabs.com/concepts/git-for-data/commits-refs.md`
+- Data branches: `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
@@ -383,7 +383,7 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Relevant concept pages:**
 - Tables: `https://docs.bauplanlabs.com/concepts/tables.md`
 - Namespaces: `https://docs.bauplanlabs.com/concepts/namespaces.md`
-- Data branches: `https://docs.bauplanlabs.com/concepts/git_for_data/data_branches.md`
+- Data branches: `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
 

--- a/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
@@ -293,10 +293,10 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
 
 **Relevant guides and concept pages:**
-- Import data: `https://docs.bauplanlabs.com/guides/import_data.md`
-- Schema conflicts: `https://docs.bauplanlabs.com/guides/schema_conflicts.md`
-- Handle casting programmatically: `https://docs.bauplanlabs.com/guides/casting.md`
-- Data branches: `https://docs.bauplanlabs.com/concepts/git_for_data/data_branches.md`
+- Import data: `https://docs.bauplanlabs.com/tutorial/03-import.md`
+- Schema conflicts: `https://docs.bauplanlabs.com/concepts/schema-conflicts.md`
+- Handle casting programmatically: `https://docs.bauplanlabs.com/concepts/schema-conflicts.md`
+- Data branches: `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md`
 - Tables: `https://docs.bauplanlabs.com/concepts/tables.md`
 - Namespaces: `https://docs.bauplanlabs.com/concepts/namespaces.md`
 


### PR DESCRIPTION
Some links were broken/imprecise, mostly due to:
1. Outdated pages, not available after doc refactoring
2. Absence of ".md" to improve LLM parsing
3. Conflicts between "_" and "-" (docs require "-")