### PR TITLE
Improve readme with codex and cursor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# Bauplan
 
 ## Git Workflow (code repo)
 
@@ -112,7 +112,7 @@ When unsure about a method, flag, or concept, fetch the relevant page rather tha
 
 ## Skills
 
-Skills whose names start with `bauplan-` contain use-case-specific instructions (e.g., building pipelines, ingesting data, debugging failed runs). Skills are auto-downloaded with the Claude Code plugin; when a relevant skill is available, follow its guidance for that workflow.
+Skills whose names start with `bauplan-` contain use-case-specific instructions (e.g., building pipelines, ingesting data, debugging failed runs); when a relevant skill is available, follow its guidance for that workflow.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 The recommended setup for developing on [Bauplan](https://www.bauplanlabs.com/) with AI coding assistants. This repo provides two things that work together:
 
-1. **Skills plugin** — task-specific workflows (build pipelines, ingest data, debug failures, etc.) that Claude Code can follow autonomously.
-2. **CLAUDE.md** — project-level instructions (safety rules, CLI/SDK guidance, authentication) that ground every conversation in Bauplan best practices.
+1. **Skills plugin** — task-specific workflows (build pipelines, ingest data, debug failures, etc.) that AI assistants can follow autonomously.
+2. **Context file** — project-level instructions (safety rules, CLI/SDK guidance, authentication) that ground every conversation in Bauplan best practices.
 
-Install the plugin for the skills, and copy or integrate the `CLAUDE.md` into your own repo for the baseline context. Both are part of the same workflow — AI-assisted development on Bauplan.
+Install the skills for your AI assistant of choice, and copy or integrate the context file into your own repo for the baseline context. Both are part of the same workflow — AI-assisted development on Bauplan.
 
-## Install the plugin
+## Table of Contents
+
+- [Claude Code](#claude-code)
+- [Codex](#codex)
+- [Cursor](#cursor)
+- [Skills](#skills)
+- [License](#license)
+
+---
+
+## Claude Code
+
+### Install the plugin
 
 1. Add the marketplace:
 ```
@@ -25,7 +37,7 @@ Restart Claude Code to make sure the changes are visible.
 
 4. Restart Claude Code.
 
-## Use the CLAUDE.md
+### Use the CLAUDE.md
 
 Copy `CLAUDE.md` from this repo into the root of your project, or merge its contents into your existing `CLAUDE.md`:
 
@@ -34,6 +46,57 @@ curl -o CLAUDE.md https://raw.githubusercontent.com/BauplanLabs/bauplan-skills/m
 ```
 
 This gives Claude Code the baseline context it needs — safety rules, CLI vs SDK guidance, authentication setup, and pointers to the skills — even before any skill is triggered.
+
+---
+
+## Codex
+
+### Install skills
+
+Inside Codex, run the skill installer pointing at the Bauplan skills directory:
+
+```
+$skill-installer https://github.com/BauplanLabs/bauplan-skills/tree/main/plugins/bauplan/skills
+```
+
+Codex will fetch and install the Bauplan skills automatically. Restart Codex once the installer completes.
+
+To verify the installation, run `/skills` and select **List skills** — you should see the Bauplan skills listed.
+
+### Use the AGENTS.md
+
+Codex uses `AGENTS.md` as its project context file. Copy it into the root of your project:
+
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/BauplanLabs/bauplan-skills/main/CLAUDE.md
+```
+
+---
+
+## Cursor
+
+### Install skills
+
+Go to **Settings > Cursor Settings > Rules, Skills, Subagents**.
+
+From there you have two options:
+
+- **If you already use Claude Code** with Bauplan skills installed: enable the **Include third-party Plugins, Skills and Other Configs** toggle. Bauplan skills will appear automatically — no additional import needed.
+
+- **If you only use Cursor**: in the Skills section, click **New** and prompt the agent to import Bauplan skills from:
+  ```
+  https://github.com/BauplanLabs/bauplan-skills/tree/main/plugins/bauplan/skills
+  ```
+
+### Use the AGENTS.md
+
+Cursor supports [granular rules](https://cursor.com/docs/rules), but `AGENTS.md` works too. Copy it into the root of your project:
+
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/BauplanLabs/bauplan-skills/main/CLAUDE.md
+```
+
+---
 
 ## Skills
 


### PR DESCRIPTION
This PR addresses 2 problems:
1. The README only addresses Claude Code, but in fact there are no particular reasons why one could not use Codex or Cursor. 
2. The CLAUDE.md file (aside from the name) contains minor references to Claude Code. Codex and Cursor use a similar file (named AGENTS.md) so it makes sense to strip reference to Claude out of the content (but possibly not from the name) of the file. 