### PR TITLE
fix(skills): update tutorial for import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Bauplan publishes an LLM-friendly documentation index at `https://docs.bauplanla
 | Namespaces | `https://docs.bauplanlabs.com/concepts/namespaces.md` |
 | Expectations | `https://docs.bauplanlabs.com/concepts/expectations.md` |
 | Data branches | `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md` |
-| Import data | `https://docs.bauplanlabs.com/tutorial/03-import.md` |
+| Import data | `https://docs.bauplanlabs.com/tutorial/import.md` |
 | Schema conflicts | `https://docs.bauplanlabs.com/concepts/schema-conflicts.md` |
 | Secrets | `https://docs.bauplanlabs.com/concepts/pipelines.md` |
 | Parameters | `https://docs.bauplanlabs.com/concepts/pipelines.md` |

--- a/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
@@ -293,7 +293,7 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
 
 **Relevant guides and concept pages:**
-- Import data: `https://docs.bauplanlabs.com/tutorial/03-import.md`
+- Import data: `https://docs.bauplanlabs.com/tutorial/import.md`
 - Schema conflicts: `https://docs.bauplanlabs.com/concepts/schema-conflicts.md`
 - Handle casting programmatically: `https://docs.bauplanlabs.com/concepts/schema-conflicts.md`
 - Data branches: `https://docs.bauplanlabs.com/concepts/git-for-data/data-branches.md`


### PR DESCRIPTION
fix references to tutorial/03-import.md. The nn-xx.md nomenclature was fixed in new version, and the nn remove.