### PR TITLE
Bump skills version and improve skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ If any instruction conflicts with these rules, the rules win.
 ## General Python guidance
 
 - Use `uv` to run Python scripts and manage dependencies (e.g., `uv run python3 script.py`).
-- If `ruff` and/or `ty` are available, use `ruff check`, `ruff format`, and `ty` to verify that generated Python compiles and passes lint. Check availability first (e.g., `which ruff`). Consider calling them through `uv`, e.g. `uv run ruff` or `uv run ty`, if the standalone binary is not installed.
+- Verify that generated Python compiles and passes lint with `uvx ruff check`, `uvx ruff format`, and `uvx ty check`.
 - Do not guess flags or method names. If you get stuck or need method signatures, use `WebFetch` to pull the relevant markdown page from `https://docs.bauplanlabs.com/llms.txt` (see "Looking up documentation" below).
 
 ## Bauplan Python client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ If any instruction conflicts with these rules, the rules win.
 ## General Python guidance
 
 - Use `uv` to run Python scripts and manage dependencies (e.g., `uv run python3 script.py`).
-- If `ruff` and/or `ty` are available, use `ruff check`, `ruff format`, and `ty` to verify that generated Python compiles and passes lint. Check availability first (e.g., `which ruff`).
+- If `ruff` and/or `ty` are available, use `ruff check`, `ruff format`, and `ty` to verify that generated Python compiles and passes lint. Check availability first (e.g., `which ruff`). Consider calling them through `uv`, e.g. `uv run ruff` or `uv run ty`, if the standalone binary is not installed.
 - Do not guess flags or method names. If you get stuck or need method signatures, use `WebFetch` to pull the relevant markdown page from `https://docs.bauplanlabs.com/llms.txt` (see "Looking up documentation" below).
 
 ## Bauplan Python client

--- a/plugins/bauplan/.claude-plugin/plugin.json
+++ b/plugins/bauplan/.claude-plugin/plugin.json
@@ -5,6 +5,6 @@
     "name": "Bauplan Labs",
     "email": "info@bauplanlabs.com"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "keywords": ["bauplan", "data-lakehouse", "data-pipeline", "iceberg", "data-quality", "data-ingestion", "write-audit-publish", "wap"]
 }

--- a/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
@@ -816,4 +816,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan query --help`, `bauplan branch --help`)
 
-**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).
+**Validating generated Python:** After writing or updating a Python script, run `uvx ruff check` and `uvx ruff format` to catch syntax errors and style issues, and `uvx ty check` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it.

--- a/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-assessment/SKILL.md
@@ -816,4 +816,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan query --help`, `bauplan branch --help`)
 
-**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors — these verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`).
+**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).

--- a/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
@@ -226,7 +226,7 @@ bauplan query "SELECT * FROM <namespace>.<output_table> LIMIT 5"
 ```
 
 ### Strict Mode
-Strict mode is on by default: the run fails immediately on runtime warnings, which include output schema mismatches and failing expectations. Pass `--no-strict` when you want those reported without failing the run, for example while iterating on a check you expect to fail:
+Strict mode is on by default: the run fails immediately on failing expectations. Pass `--no-strict` when you want those reported without failing the run, for example while iterating on a check you expect to fail:
 ```bash
 bauplan run --dry-run --no-strict
 bauplan run --no-strict
@@ -306,7 +306,7 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan-standard-expectations.md`
 
 **Relevant concept pages:**
-- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic_annotations.md`
+- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic-annotations.md`
 - Models: `https://docs.bauplanlabs.com/concepts/models.md`
 - Pipelines: `https://docs.bauplanlabs.com/concepts/pipelines.md`
 - Projects: `https://docs.bauplanlabs.com/concepts/projects.md`
@@ -320,4 +320,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan run --help`, `bauplan table --help`)
 
-**Validating generated Python:** After writing or updating `models.py` or `expectations.py`, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`). This is the fast first gate, always before `bauplan run --dry-run`.
+**Validating generated Python:** After writing or updating `models.py` or `expectations.py`, run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`). This is the fast first gate, always before `bauplan run --dry-run`.

--- a/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-pipeline/SKILL.md
@@ -39,7 +39,7 @@ Before writing a pipeline, you MUST gather the following from the user:
 2. **Source tables** (required): Which tables from the lakehouse should be used as inputs? Verify they exist with `bauplan table get <namespace>.<table_name>`.
 3. **Output tables** (required): Which tables should be materialized as final outputs?
 4. **Materialization strategy** (optional, default: `REPLACE`): Should output tables use `REPLACE` or `APPEND`?
-5. **Strict mode** (optional, default: on): Should runtime warnings and failing expectations be allowed to pass, which needs `--no-strict`?
+5. **Strict mode** (optional, default: on): Should failing expectations be allowed to pass, which needs `--no-strict`?
 
 **If any required item is missing, ask the user before writing any code.**
 
@@ -204,7 +204,7 @@ project:
 Always run from inside the project directory (the folder containing `bauplan_project.yml`).
 
 ### Type Checking
-The annotations are what make a pipeline checkable without running it, so use them. Before any `bauplan` command, run a type checker from the project directory: `uv run ty check`, or `ty check` if the project is not managed by uv. Model runtime dependencies (polars, duckdb, local utility modules) live in the remote model environment, so the checker reports them as unresolved imports. Fix that by adding them to the project's dev dependencies, `uv add --dev polars`, ideally at the version pinned in `@bauplan.python(pip={...})`: it only affects the local checker, never what the model runs with, and it keeps the report clean without suppression comments scattered through the models. Unresolved `bauplan` symbols are a different matter and always a real error.
+The annotations are what make a pipeline checkable without running it, so use them. Before any `bauplan` command, run the type checker from the project directory with `uvx ty check`. Model runtime dependencies (polars, duckdb, local utility modules) live in the remote model environment, so the checker reports them as unresolved imports. Fix that by adding them to the project's dev dependencies, `uv add --dev polars`, ideally at the version pinned in `@bauplan.python(pip={...})`: it only affects the local checker, never what the model runs with, and it keeps the report clean without suppression comments scattered through the models. Unresolved `bauplan` symbols are a different matter and always a real error.
 
 ### Dry Run
 A dry run validates the pipeline without materializing tables: DAG wiring, source tables, SQL, and schema references. Always dry-run before a full run.
@@ -250,7 +250,7 @@ After writing models, verify each model has the correct `materialization_strateg
 - [ ] Step 6: Create project folder with `bauplan_project.yml`
 - [ ] Step 7: Write Python models respecting the best practices above
 - [ ] Step 8: Verify materialization (see Materialization Checklist)
-- [ ] Step 9: Type check → `uv run ty check` (or `ty check`), fix everything it reports
+- [ ] Step 9: Type check → `uvx ty check`, fix everything it reports
 - [ ] Step 10: Dry run → `bauplan run --dry-run`
 - [ ] Step 11: Full run → `bauplan run`
 - [ ] Step 12: Verify output → `bauplan table get` + `bauplan query`
@@ -320,4 +320,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan run --help`, `bauplan table --help`)
 
-**Validating generated Python:** After writing or updating `models.py` or `expectations.py`, run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`). This is the fast first gate, always before `bauplan run --dry-run`.
+**Validating generated Python:** After writing or updating `models.py` or `expectations.py`, run `uvx ruff check` and `uvx ruff format` to catch syntax errors and style issues, and `uvx ty check` to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. This is the fast first gate, always before `bauplan run --dry-run`.

--- a/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
@@ -527,7 +527,7 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 **Standard expectations:** `https://docs.bauplanlabs.com/reference/bauplan-standard-expectations.md`
 
 **Relevant concept pages:**
-- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic_annotations.md`
+- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic-annotations.md`
 - Expectations: `https://docs.bauplanlabs.com/concepts/expectations.md`
 
 **Full doc index:** `https://docs.bauplanlabs.com/llms.txt`
@@ -536,4 +536,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan run --help`, `bauplan job --help`)
 
-**Validating generated Python:** After writing or updating `expectations.py` or validation code, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`).
+**Validating generated Python:** After writing or updating `expectations.py` or validation code, run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).

--- a/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-data-quality-checks/SKILL.md
@@ -391,11 +391,11 @@ SQL models use `-- bauplan: output_schema = SchemaName` referencing a `TableSche
 
 ### Running and Verifying
 
-Type check first: the annotations on expectations and projection schemas make `uv run ty check` (or `ty check`) a local gate that catches misspelled field types, unknown `bauplan` symbols, and schema classes that do not resolve, in seconds and without submitting a job. Imports of model runtime dependencies (polars, duckdb) resolve only in the remote environment, so add them to the project's dev dependencies (`uv add --dev polars`) to keep the report clean. Only then go to the platform.
+Type check first: the annotations on expectations and projection schemas make `uvx ty check` a local gate that catches misspelled field types, unknown `bauplan` symbols, and schema classes that do not resolve, in seconds and without submitting a job. Imports of model runtime dependencies (polars, duckdb) resolve only in the remote environment, so add them to the project's dev dependencies (`uv add --dev polars`) to keep the report clean. Only then go to the platform.
 
 ```bash
 # First gate: annotations are checked locally, before any job is submitted
-uv run ty check
+uvx ty check
 
 # Validate declarations and schema references without materializing
 bauplan run --dry-run
@@ -536,4 +536,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan run --help`, `bauplan job --help`)
 
-**Validating generated Python:** After writing or updating `expectations.py` or validation code, run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors and style issues, and `uv run ty check` (or `ty check`) to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).
+**Validating generated Python:** After writing or updating `expectations.py` or validation code, run `uvx ruff check` and `uvx ruff format` to catch syntax errors and style issues, and `uvx ty check` to catch type errors: these verify the code compiles and the annotations and SDK calls are well-formed without executing it.

--- a/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
@@ -287,7 +287,7 @@ Before rerunning, assess what you can actually prove:
 
 #### Execute
 
-After editing annotated code, type check before you rerun: `uv run ty check` (or `ty check`) in the project directory catches broken annotations, schema classes that do not resolve, and wrong SDK keywords locally, in seconds, so the rerun tests the fix instead of a typo.
+After editing annotated code, type check before you rerun: `uvx ty check` in the project directory catches broken annotations, schema classes that do not resolve, and wrong SDK keywords locally, in seconds, so the rerun tests the fix instead of a typo.
 
 For typed pipelines, a dry run checks declarations and schema references; a full run is required to validate actual Arrow output types against their contracts.
 
@@ -414,4 +414,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan job --help`, `bauplan run --help`, `bauplan branch --help`)
 
-**Validating Python fixes:** After editing pipeline code (models, expectations), run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors, and `ty` to catch type errors before rerunning the pipeline. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).
+**Validating Python fixes:** After editing pipeline code (models, expectations), run `uvx ruff check` and `uvx ruff format` to catch syntax errors, and `uvx ty check` to catch type errors before rerunning the pipeline.

--- a/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-debug-and-fix-pipeline/SKILL.md
@@ -414,4 +414,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan job --help`, `bauplan run --help`, `bauplan branch --help`)
 
-**Validating Python fixes:** After editing pipeline code (models, expectations), run `ruff check` and `ruff format` to catch syntax errors, and `ty` to catch type errors before rerunning the pipeline. Only run these if they are installed (check with `which ruff` / `which ty`).
+**Validating Python fixes:** After editing pipeline code (models, expectations), run `ruff check` and `ruff format` (or `uv run ruff check/format`) to catch syntax errors, and `ty` to catch type errors before rerunning the pipeline. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).

--- a/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
@@ -391,4 +391,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan query --help`, `bauplan table --help`)
 
-**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors — these verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`).
+**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors — these verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).

--- a/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-explore-data/SKILL.md
@@ -391,4 +391,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan query --help`, `bauplan table --help`)
 
-**Validating generated Python:** After writing or updating a Python script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors — these verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).
+**Validating generated Python:** After writing or updating a Python script, run `uvx ruff check` and `uvx ruff format` to catch syntax errors and style issues, and `uvx ty check` to catch type errors: these verify the code compiles and the SDK calls are well-formed without executing it.

--- a/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/SKILL.md
@@ -54,6 +54,7 @@ Read every `models.py`, `expectations.py`, other `*.py` model files, `*.sql` fil
 - every `bauplan.Model(...)` input and its `columns` / `filter` / other kwargs
 - every `bauplan.Parameter(...)` and its `type:` in `bauplan_project.yml`
 - every `columns=[...]` on a `@bauplan.model()` decorator
+- every `internet_access=...` on a `@bauplan.model()` decorator
 - every model return statement and what it returns (arrow, polars, pandas, list of dicts)
 
 ### Step 2: Check for blockers
@@ -64,6 +65,7 @@ The constructs below have no direct equivalent in the typed SDK. If found, repor
 - A `filter=` built from an f-string or variable: the new `filter` must be a string literal (`$param` templating inside the literal is fine).
 - The legacy decorators `@bauplan.resources()`, `@bauplan.extras()` are not supported anymore and need to be removed. Confirm with user.
 - The use of `filter=` on models now applies only to tables read from the catalog; when applied to other models (nodes in the DAG) it results in an error. This is not a hard-blocker since one can move the logic inside the body of the function.
+- The `@bauplan.model()` kwarg `internet_access` is not supported anymore. Flag to the user.
 
 ### Step 3: Discover column types
 
@@ -113,7 +115,7 @@ Work on an isolated branch: `bauplan checkout -b <username>.<branch> --from-ref 
 
 Validation ladder, from cheapest to most complete:
 
-1. **Static checks**, only if installed (`which ruff` / `which ty`): `ruff check` and `ty check` (or `uv run ty check`) on the project. This is the payoff of the migration: the typed SDK ships stubs, so a wrong kwarg, a misspelled field type, or a schema class that does not resolve fails here in seconds, locally, before any job reaches the platform. Never skip it.
+1. **Static checks**, only if installed (`which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`): `ruff check` and `ty check` on the project. This is the payoff of the migration: the typed SDK ships stubs, so a wrong kwarg, a misspelled field type, or a schema class that does not resolve fails here in seconds, locally, before any job reaches the platform. Never skip it.
 2. **Dry run**: `bauplan run --dry-run`. Schema contracts are enforced on every run, there is no flag to opt in, and strict mode is the default so a warning fails the run.
 3. **Full run** on the isolated branch: `bauplan run`. Runtime dtype mismatches (unsigned counts, float widths) and extra output columns only surface here, as `ModelOutputContractError`.
 
@@ -151,7 +153,7 @@ When unsure about a signature or concept, fetch the doc page via `WebFetch` rath
 **Python SDK:** `https://docs.bauplanlabs.com/reference/bauplan.md`
 
 **Relevant concept pages:**
-- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic_annotations.md`
+- Semantic annotations: `https://docs.bauplanlabs.com/concepts/semantic-annotations.md`
 - Models: `https://docs.bauplanlabs.com/concepts/models.md`
 - Expectations: `https://docs.bauplanlabs.com/concepts/expectations.md`
 - Parameters: `https://docs.bauplanlabs.com/common-scenarios/parameterized-runs.md`

--- a/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash(bauplan:*)
   - Bash(uv:*)
   - Bash(pip:*)
+  - Bash(uvx:*)
   - Bash(ruff:*)
   - Bash(ty:*)
   - Read
@@ -115,8 +116,8 @@ Work on an isolated branch: `bauplan checkout -b <username>.<branch> --from-ref 
 
 Validation ladder, from cheapest to most complete:
 
-1. **Static checks**, only if installed (`which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`): `ruff check` and `ty check` on the project. This is the payoff of the migration: the typed SDK ships stubs, so a wrong kwarg, a misspelled field type, or a schema class that does not resolve fails here in seconds, locally, before any job reaches the platform. Never skip it.
-2. **Dry run**: `bauplan run --dry-run`. Schema contracts are enforced on every run, there is no flag to opt in, and strict mode is the default so a warning fails the run.
+1. **Static checks**: `uvx ruff check` and `uvx ty check` on the project. This is the payoff of the migration: the typed SDK ships stubs, so a wrong kwarg, a misspelled field type, or a schema class that does not resolve fails here in seconds, locally, before any job reaches the platform. Never skip it.
+2. **Dry run**: `bauplan run --dry-run`. Schema contracts are enforced on every run, there is no flag to opt in, and strict mode is the default so a failing expectation halts the run.
 3. **Full run** on the isolated branch: `bauplan run`. Runtime dtype mismatches (unsigned counts, float widths) and extra output columns only surface here, as `ModelOutputContractError`.
 
 Known error signatures and their causes:
@@ -143,7 +144,7 @@ Summarize for the user: files rewritten, schema classes created (and which table
 - [ ] Step 3: Read source table schemas → `bauplan table get <namespace>.<table>`
 - [ ] Step 4: Upgrade Python to >= 3.11 (**mandatory**), then the project dependency to the typed SDK (0.3.x)
 - [ ] Step 5: Rewrite files following [examples.md](examples.md)
-- [ ] Step 6: Create validation branch → `ty check` → dry run → full run → iterate until green
+- [ ] Step 6: Create validation branch → `uvx ty check` → dry run → full run → iterate until green
 - [ ] Step 7: Report changes, flagged expectations, and leftovers to the user
 
 ## Reference

--- a/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/examples.md
+++ b/plugins/bauplan/skills/bauplan-migrate-to-typed-sdk/examples.md
@@ -122,7 +122,8 @@ def daily_segment_stats(...) -> Annotated[pa.Table, DailySegmentStats]:
 
 - Every migrated model gets a return annotation, including models that declared no `columns` at all in the old code. This is not optional: a model without `-> Annotated[pa.Table, SchemaType]` fails at parse time with `Model must have a valid return type annotation`, and a bare `-> pa.Table` fails with `Model return type annotation must be of the form: Annotated[pyarrow.Table, SchemaType]`.
 - The old wildcard `columns=['*']` has no equivalent: enumerate the actual output columns.
-- All other `@bauplan.model()` kwargs are unchanged: `name`, `materialization_strategy`, `cache_strategy`, `partitioned_by`, `overwrite_filter`, `internet_access`.
+- The `@bauplan.model()` kwarg `internet_access` is not supported anymore.
+- All other `@bauplan.model()` kwargs are unchanged: `name`, `materialization_strategy`, `cache_strategy`, `partitioned_by`, `overwrite_filter`.
 - The declared output schema is exhaustive and enforced on every run, with no flag to opt in: the function must return exactly the declared columns, with the declared types and nullability. An extra column fails the run with `ModelOutputContractError` just as a missing one does.
 
 ## 5. Declaring `TableSchema` classes
@@ -377,7 +378,7 @@ Note how the output schema declares what the function actually produces: `Age` s
 Everything below is unchanged between 0.1.x/0.2.x and 0.3.0+. Leave it alone:
 
 - `@bauplan.python(version, pip={...})`, `@bauplan.expectation()` (however, do ensure the python version is always passed, or else it will fail!)
-- `@bauplan.model()` kwargs other than `columns`: `name`, `materialization_strategy`, `cache_strategy`, `partitioned_by`, `overwrite_filter`, `internet_access`
+- `@bauplan.model()` kwargs other than `columns`: `name`, `materialization_strategy`, `cache_strategy`, `partitioned_by`, `overwrite_filter`
 - Decorator ordering (`@bauplan.model` above or below `@bauplan.python`, both valid)
 - `filter=` syntax and `$param` templating
 - `bauplan_project.yml` structure (no new keys required by the migration)

--- a/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
@@ -309,4 +309,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan branch --help`, `bauplan import-data --help`)
 
-**Validating generated Python:** After writing or updating the ingestion script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors — these verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`).
+**Validating generated Python:** After writing or updating the ingestion script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).

--- a/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
+++ b/plugins/bauplan/skills/bauplan-safe-ingestion/SKILL.md
@@ -309,4 +309,4 @@ When unsure about a method signature, CLI flag, or concept, fetch the relevant d
 - `bauplan --help` — lists all available commands
 - `bauplan <command> --help` — shows arguments and options for a specific command (e.g., `bauplan branch --help`, `bauplan import-data --help`)
 
-**Validating generated Python:** After writing or updating the ingestion script, run `ruff check` and `ruff format` to catch syntax errors and style issues, and `ty` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it. Only run these if they are installed (check with `which ruff` / `which ty`, or use `uv run ruff` or `uv run ty`).
+**Validating generated Python:** After writing or updating the ingestion script, run `uvx ruff check` and `uvx ruff format` to catch syntax errors and style issues, and `uvx ty check` to catch type errors. These verify the code compiles and the SDK calls are well-formed without executing it.


### PR DESCRIPTION
Bump skills version to `2.0.0` and improve skills:
1. Use of `uv run ruff` instead of `ruff`; 
2. Clarification on enforcement of expectations vs type contracts;
3. Deprecation of `internet_access` kwarg.
4. Fix link to docs